### PR TITLE
[Feature] 최종 일일 소비 한도 저장 API #11

### DIFF
--- a/src/main/java/cheongsan/common/constant/ResponseMessage.java
+++ b/src/main/java/cheongsan/common/constant/ResponseMessage.java
@@ -1,0 +1,24 @@
+package cheongsan.common.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum ResponseMessage {
+
+    // --- 성공 ---
+    BUDGET_LIMIT_SAVED("일일 소비 한도가 성공적으로 저장되었습니다."),
+
+    // --- 에러 ---
+    INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다."),
+    USER_NOT_FOUND("일치하는 회원 정보가 없습니다."),
+    UNSUPPORTED_REPAYMENT_METHOD("지원하지 않는 상환방식입니다."),
+    BUDGET_LIMIT_EXCEEDED("설정된 한도는 시스템 추천 한도를 초과할 수 없습니다."),
+    BUDGET_UPDATE_RULE_VIOLATED("소비 한도는 주 1회만 수정할 수 있습니다."),
+    INCOME_NOT_FOUND_FOR_BUDGET_RECOMMENDATION("추천 한도를 계산하기 위해 월 소득 정보가 필요합니다.");
+
+    private final String message;
+
+    ResponseMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/cheongsan/common/exception/GlobalException.java
+++ b/src/main/java/cheongsan/common/exception/GlobalException.java
@@ -1,5 +1,6 @@
 package cheongsan.common.exception;
 
+import cheongsan.common.constant.ResponseMessage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -9,14 +10,20 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalException {
 
     @ExceptionHandler(IllegalStateException.class)
-    public ResponseEntity<ErrorResponseDTO> handleIllegalStateException(IllegalStateException e) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(e.getMessage());
+    public ResponseEntity<ResponseDTO> handleIllegalStateException(IllegalStateException e) {
+        ResponseDTO errorResponse = new ResponseDTO(e.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ResponseDTO> handleIllegalArgumentException(IllegalArgumentException e) {
+        ResponseDTO errorResponse = new ResponseDTO(e.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponseDTO> handleException(Exception e) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO("서버 내부 오류가 발생했습니다.");
+    public ResponseEntity<ResponseDTO> handleException(Exception e) {
+        ResponseDTO errorResponse = new ResponseDTO(ResponseMessage.INTERNAL_SERVER_ERROR.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/cheongsan/common/exception/ResponseDTO.java
+++ b/src/main/java/cheongsan/common/exception/ResponseDTO.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @AllArgsConstructor
 @Data
-public class ErrorResponseDTO {
+public class ResponseDTO {
 
     private String message;
 }

--- a/src/main/java/cheongsan/common/util/LoanCalculator.java
+++ b/src/main/java/cheongsan/common/util/LoanCalculator.java
@@ -1,5 +1,6 @@
 package cheongsan.common.util;
 
+import cheongsan.common.constant.ResponseMessage;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
@@ -38,7 +39,7 @@ public class LoanCalculator {
             case BULLET_REPAYMENT:
                 return calculateBulletRepayment(originalAmount, interestRate);
             default:
-                throw new IllegalArgumentException("지원하지 않는 상환방식입니다.");
+                throw new IllegalArgumentException(ResponseMessage.UNSUPPORTED_REPAYMENT_METHOD.getMessage());
         }
     }
 

--- a/src/main/java/cheongsan/domain/deposit/controller/BudgetController.java
+++ b/src/main/java/cheongsan/domain/deposit/controller/BudgetController.java
@@ -1,13 +1,14 @@
 package cheongsan.domain.deposit.controller;
 
+import cheongsan.common.constant.ResponseMessage;
+import cheongsan.common.exception.ResponseDTO;
 import cheongsan.domain.deposit.dto.BudgetLimitDTO;
+import cheongsan.domain.deposit.dto.DailyLimitRequestDTO;
 import cheongsan.domain.deposit.service.BudgetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,8 +21,18 @@ public class BudgetController {
     public ResponseEntity<BudgetLimitDTO> getBudgetLimits() {
         Long userId = 1L;
 
-        BudgetLimitDTO resultDto = budgetService.getBudgetLimits(userId);
+        BudgetLimitDTO result = budgetService.getBudgetLimits(userId);
 
-        return new ResponseEntity<>(resultDto, HttpStatus.OK);
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+    @PatchMapping
+    public ResponseEntity<ResponseDTO> saveFinalDailyLimit(@RequestBody DailyLimitRequestDTO request) {
+        Long userId = 1L;
+
+        budgetService.saveFinalDailyLimit(userId, request.getDailyLimit());
+        ResponseDTO response = new ResponseDTO(ResponseMessage.BUDGET_LIMIT_SAVED.getMessage());
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/cheongsan/domain/deposit/dto/BudgetLimitDTO.java
+++ b/src/main/java/cheongsan/domain/deposit/dto/BudgetLimitDTO.java
@@ -11,4 +11,5 @@ public class BudgetLimitDTO {
 
     private final int recommendedDailyLimit;
     private final int maximumDailyLimit;
+    private final int currentDailyLimit;
 }

--- a/src/main/java/cheongsan/domain/deposit/dto/DailyLimitRequestDTO.java
+++ b/src/main/java/cheongsan/domain/deposit/dto/DailyLimitRequestDTO.java
@@ -1,0 +1,9 @@
+package cheongsan.domain.deposit.dto;
+
+import lombok.Data;
+
+@Data
+public class DailyLimitRequestDTO {
+
+    private int dailyLimit;
+}

--- a/src/main/java/cheongsan/domain/deposit/service/BudgetService.java
+++ b/src/main/java/cheongsan/domain/deposit/service/BudgetService.java
@@ -5,4 +5,6 @@ import cheongsan.domain.deposit.dto.BudgetLimitDTO;
 public interface BudgetService {
 
     BudgetLimitDTO getBudgetLimits(Long userId);
+
+    void saveFinalDailyLimit(Long userId, int finalDailyLimit);
 }

--- a/src/main/java/cheongsan/domain/deposit/service/BudgetServiceImpl.java
+++ b/src/main/java/cheongsan/domain/deposit/service/BudgetServiceImpl.java
@@ -1,14 +1,20 @@
 package cheongsan.domain.deposit.service;
 
+import cheongsan.common.constant.ResponseMessage;
 import cheongsan.domain.debt.service.DebtService;
 import cheongsan.domain.deposit.dto.BudgetLimitDTO;
+import cheongsan.domain.user.entity.User;
+import cheongsan.domain.user.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
 
 @Log4j2
 @Service
@@ -17,12 +23,19 @@ public class BudgetServiceImpl implements BudgetService {
 
     private final DepositService depositService;
     private final DebtService debtService;
+    private final UserMapper userMapper;
 
     private static final BigDecimal RECOMMENDATION_RATE = new BigDecimal("0.7");
     private static final int DAYS_IN_MONTH = 30;
 
     @Override
     public BudgetLimitDTO getBudgetLimits(Long userId) {
+        User user = userMapper.findById(userId);
+        if (user == null) {
+            throw new IllegalArgumentException(ResponseMessage.USER_NOT_FOUND.getMessage());
+        }
+        int currentDailyLimit = (user.getDailyLimit() != null) ? user.getDailyLimit().intValue() : 0;
+
         BigDecimal availableMonthlySpending = calculateAvailableMonthlySpending(userId);
 
         BigDecimal maximumDailyLimit = availableMonthlySpending.divide(
@@ -33,7 +46,30 @@ public class BudgetServiceImpl implements BudgetService {
                 .multiply(RECOMMENDATION_RATE)
                 .setScale(0, RoundingMode.DOWN);
 
-        return new BudgetLimitDTO(recommendedDailyLimit.intValue(), maximumDailyLimit.intValue());
+        return new BudgetLimitDTO(
+                recommendedDailyLimit.intValue(),
+                maximumDailyLimit.intValue(),
+                currentDailyLimit
+        );
+    }
+
+    @Override
+    public void saveFinalDailyLimit(Long userId, int finalDailyLimit) {
+        User user = userMapper.findById(userId);
+        if (user == null) {
+            throw new IllegalArgumentException(ResponseMessage.USER_NOT_FOUND.getMessage());
+        }
+
+        checkIfUpdateIsAllowed(user.getDailyLimitDate());
+
+        BigDecimal maximumDailyLimit = calculateAvailableMonthlySpending(userId)
+                .divide(new BigDecimal(DAYS_IN_MONTH), 0, RoundingMode.DOWN);
+
+        if (new BigDecimal(finalDailyLimit).compareTo(maximumDailyLimit) > 0) {
+            throw new IllegalArgumentException(ResponseMessage.BUDGET_LIMIT_EXCEEDED.getMessage());
+        }
+
+        userMapper.updateDailyLimit(userId, new BigDecimal(finalDailyLimit), LocalDateTime.now());
     }
 
     private BigDecimal calculateAvailableMonthlySpending(Long userId) {
@@ -45,7 +81,7 @@ public class BudgetServiceImpl implements BudgetService {
         );
 
         if (monthlyTransfer == null || monthlyTransfer.compareTo(BigDecimal.ZERO) <= 0) {
-            throw new IllegalStateException("추천 한도를 계산하기 위해 월 소득 정보가 필요합니다.");
+            throw new IllegalStateException(ResponseMessage.INCOME_NOT_FOUND_FOR_BUDGET_RECOMMENDATION.getMessage());
         }
 
         BigDecimal totalMonthlyDebtPayment = debtService.calculateTotalMonthlyPayment(userId);
@@ -59,5 +95,18 @@ public class BudgetServiceImpl implements BudgetService {
         BigDecimal availableMonthlySpending = monthlyTransfer.subtract(totalFixedCosts);
 
         return availableMonthlySpending.compareTo(BigDecimal.ZERO) < 0 ? BigDecimal.ZERO : availableMonthlySpending;
+    }
+
+    private void checkIfUpdateIsAllowed(LocalDateTime lastDailyLimitDate) {
+        if (lastDailyLimitDate == null) {
+            return;
+        }
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startOfWeek = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).toLocalDate().atStartOfDay();
+        LocalDateTime endOfWeek = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY)).toLocalDate().atTime(23, 59, 59);
+
+        if (!lastDailyLimitDate.isBefore(startOfWeek) && !lastDailyLimitDate.isAfter(endOfWeek)) {
+            throw new IllegalStateException(ResponseMessage.BUDGET_UPDATE_RULE_VIOLATED.getMessage());
+        }
     }
 }

--- a/src/main/java/cheongsan/domain/user/entity/User.java
+++ b/src/main/java/cheongsan/domain/user/entity/User.java
@@ -2,10 +2,13 @@ package cheongsan.domain.user.entity;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Getter
+@ToString
 @NoArgsConstructor
 public class User {
     private Long id;
@@ -13,6 +16,7 @@ public class User {
     private String nickname;
     private String email;
     private BigDecimal dailyLimit;
+    private LocalDateTime dailyLimitDate;
     private String status;
 
 }

--- a/src/main/java/cheongsan/domain/user/mapper/UserMapper.java
+++ b/src/main/java/cheongsan/domain/user/mapper/UserMapper.java
@@ -4,10 +4,17 @@ import cheongsan.domain.user.entity.User;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
 @Mapper
 public interface UserMapper {
     User findById(@Param("userId") Long id);
 
     void saveDiagnosis(@Param("userId") Long userId,
                        @Param("programId") Long programId);
+
+    void updateDailyLimit(@Param("userId") Long userId,
+                          @Param("dailyLimit") BigDecimal dailyLimit,
+                          @Param("dailyLimitDate") LocalDateTime dailyLimitDate);
 }

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -14,4 +14,11 @@
         SET recommended_program_id = #{programId}
         WHERE id = #{userId}
     </update>
+
+    <update id="updateDailyLimit">
+        UPDATE user
+        SET daily_limit      = #{dailyLimit},
+            daily_limit_date = #{dailyLimitDate}
+        WHERE id = #{userId}
+    </update>
 </mapper>

--- a/src/test/java/cheongsan/domain/user/mapper/UserMapperTest.java
+++ b/src/test/java/cheongsan/domain/user/mapper/UserMapperTest.java
@@ -1,0 +1,49 @@
+package cheongsan.domain.user.mapper;
+
+import cheongsan.common.config.RootConfig;
+import cheongsan.domain.user.entity.User;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {RootConfig.class})
+@Log4j2
+class UserMapperTest {
+
+    @Autowired
+    private UserMapper userMapper;
+
+    @Test
+    @DisplayName("사용자의 일일 소비 한도와 마지막 수정 시각을 정확히 업데이트해야 한다")
+    void updateDailyLimit() {
+        // given
+        Long userId = 1L;
+        BigDecimal newLimit = new BigDecimal("35000");
+        LocalDateTime newTimestamp = LocalDateTime.now();
+
+        // when
+        userMapper.updateDailyLimit(userId, newLimit, newTimestamp);
+
+        // then
+        User updatedUser = userMapper.findById(userId);
+
+        assertNotNull(updatedUser, "업데이트 후 사용자를 조회할 수 있어야 합니다.");
+
+        assertEquals(0, newLimit.compareTo(updatedUser.getDailyLimit()), "daily_limit이 정확히 업데이트되어야 합니다.");
+
+        // LocalDateTime은 초 단위 이하에서 미세한 차이가 날 수 있으므로, 초 단위까지만 비교
+        assertEquals(newTimestamp.withNano(0), updatedUser.getDailyLimitDate().withNano(0), "daily_limit_date가 정확히 업데이트되어야 합니다.");
+
+        log.info("업데이트된 사용자 정보: " + updatedUser);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

#11 

## 📝 요약(Summary)

사용자가 최종적으로 설정한 '일일 소비 한도' 금액을 서버에 저장하는 API 구현.
사용자가 설정한 값이 시스템이 허용하는 최대 한도를 초과하지 않는지, 주 1회만 수정하는 규칙을 지키는지 검증하는 로직 포함.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
