### PR TITLE
[Feature] 예산 설정 상태 API #43

### DIFF
--- a/src/main/java/cheongsan/domain/deposit/controller/BudgetController.java
+++ b/src/main/java/cheongsan/domain/deposit/controller/BudgetController.java
@@ -3,6 +3,7 @@ package cheongsan.domain.deposit.controller;
 import cheongsan.common.constant.ResponseMessage;
 import cheongsan.common.exception.ResponseDTO;
 import cheongsan.domain.deposit.dto.BudgetLimitDTO;
+import cheongsan.domain.deposit.dto.BudgetSettingStatusDTO;
 import cheongsan.domain.deposit.dto.DailyLimitRequestDTO;
 import cheongsan.domain.deposit.service.BudgetService;
 import lombok.RequiredArgsConstructor;
@@ -34,5 +35,14 @@ public class BudgetController {
         ResponseDTO response = new ResponseDTO(ResponseMessage.BUDGET_LIMIT_SAVED.getMessage());
 
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping("/status")
+    public ResponseEntity<BudgetSettingStatusDTO> getBudgetSettingStatus() {
+        Long userId = 1L;
+
+        BudgetSettingStatusDTO result = budgetService.getBudgetSettingStatus(userId);
+
+        return new ResponseEntity<>(result, HttpStatus.OK);
     }
 }

--- a/src/main/java/cheongsan/domain/deposit/dto/BudgetSettingStatusDTO.java
+++ b/src/main/java/cheongsan/domain/deposit/dto/BudgetSettingStatusDTO.java
@@ -2,12 +2,13 @@ package cheongsan.domain.deposit.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @AllArgsConstructor
-@Getter
+@Data
 public class BudgetSettingStatusDTO {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")

--- a/src/main/java/cheongsan/domain/deposit/dto/BudgetSettingStatusDTO.java
+++ b/src/main/java/cheongsan/domain/deposit/dto/BudgetSettingStatusDTO.java
@@ -1,0 +1,15 @@
+package cheongsan.domain.deposit.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class BudgetSettingStatusDTO {
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime dailyLimitDate;
+}

--- a/src/main/java/cheongsan/domain/deposit/service/BudgetService.java
+++ b/src/main/java/cheongsan/domain/deposit/service/BudgetService.java
@@ -1,10 +1,13 @@
 package cheongsan.domain.deposit.service;
 
 import cheongsan.domain.deposit.dto.BudgetLimitDTO;
+import cheongsan.domain.deposit.dto.BudgetSettingStatusDTO;
 
 public interface BudgetService {
 
     BudgetLimitDTO getBudgetLimits(Long userId);
 
     void saveFinalDailyLimit(Long userId, int finalDailyLimit);
+
+    BudgetSettingStatusDTO getBudgetSettingStatus(Long userId);
 }

--- a/src/main/java/cheongsan/domain/deposit/service/BudgetServiceImpl.java
+++ b/src/main/java/cheongsan/domain/deposit/service/BudgetServiceImpl.java
@@ -3,6 +3,7 @@ package cheongsan.domain.deposit.service;
 import cheongsan.common.constant.ResponseMessage;
 import cheongsan.domain.debt.service.DebtService;
 import cheongsan.domain.deposit.dto.BudgetLimitDTO;
+import cheongsan.domain.deposit.dto.BudgetSettingStatusDTO;
 import cheongsan.domain.user.entity.User;
 import cheongsan.domain.user.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
@@ -70,6 +71,16 @@ public class BudgetServiceImpl implements BudgetService {
         }
 
         userMapper.updateDailyLimit(userId, new BigDecimal(finalDailyLimit), LocalDateTime.now());
+    }
+
+    @Override
+    public BudgetSettingStatusDTO getBudgetSettingStatus(Long userId) {
+        User user = userMapper.findById(userId);
+        if (user == null) {
+            throw new IllegalArgumentException(ResponseMessage.USER_NOT_FOUND.getMessage());
+        }
+
+        return new BudgetSettingStatusDTO(user.getDailyLimitDate());
     }
 
     private BigDecimal calculateAvailableMonthlySpending(Long userId) {


### PR DESCRIPTION
## #️⃣ Issue Number

#43 

## 📝 요약(Summary)

프론트엔드에서 '일일 소비 한도' 수정 UI의 활성화/비활성화 여부를 판단할 수 있도록, 사용자의 마지막 한도 수정일 정보를 제공하는 API 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
