### PR TITLE
fix: SimpleDiagnosisDTO of 메서드 접근제한자 에러 처리 #50

### DIFF
--- a/src/main/java/cheongsan/domain/policy/dto/SimpleDiagnosisDTO.java
+++ b/src/main/java/cheongsan/domain/policy/dto/SimpleDiagnosisDTO.java
@@ -18,7 +18,7 @@ public class SimpleDiagnosisDTO {
     private String simpleDescription;
 
     // Diagnosis Entity → DTO 변환 static 메서드 (Builder 활용)
-    static SimpleDiagnosisDTO of(SimpleDiagnosis simpleDiagnosis) {
+    public static SimpleDiagnosisDTO of(SimpleDiagnosis simpleDiagnosis) {
         return SimpleDiagnosisDTO.builder()
                 .id(simpleDiagnosis.getId())
                 .programName(simpleDiagnosis.getProgramName())


### PR DESCRIPTION
## #️⃣ Issue Number

#50 

## 📝 요약(Summary)

SimpleDiagnosisDTO의 of메서드 접근제한자가 default라 service에서 접근하지 못하는 에러가 발생.
public으로 변환하여 해결.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
<img width="776" height="212" alt="image" src="https://github.com/user-attachments/assets/56632657-5b82-4511-9074-d7d76f3d9a69" />


## 💬 공유사항 to 리뷰어

왜 이걸 default로 할 생각을 했을까요?

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
