### PR TITLE
[Feature] 지난주 지출 리포트 조회 API #48

### DIFF
--- a/src/main/java/cheongsan/domain/deposit/controller/ReportController.java
+++ b/src/main/java/cheongsan/domain/deposit/controller/ReportController.java
@@ -1,0 +1,27 @@
+package cheongsan.domain.deposit.controller;
+
+import cheongsan.domain.deposit.dto.WeeklyReportDTO;
+import cheongsan.domain.deposit.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/cheongsan/dashboard/reports/weekly/latest")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @GetMapping
+    public ResponseEntity<WeeklyReportDTO> getLatestWeeklyReport() {
+        Long userId = 1L;
+
+        WeeklyReportDTO result = reportService.getLatestWeeklyReport(userId);
+
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+}

--- a/src/main/java/cheongsan/domain/deposit/controller/ReportController.java
+++ b/src/main/java/cheongsan/domain/deposit/controller/ReportController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/cheongsan/dashboard/reports/weekly/latest")
+@RequestMapping("/cheongsan/dashboard/reports/weekly")
 public class ReportController {
 
     private final ReportService reportService;

--- a/src/main/java/cheongsan/domain/deposit/dto/WeeklyReportDTO.java
+++ b/src/main/java/cheongsan/domain/deposit/dto/WeeklyReportDTO.java
@@ -1,0 +1,20 @@
+package cheongsan.domain.deposit.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Map;
+
+@Getter
+@ToString
+@Builder
+public class WeeklyReportDTO {
+
+    private final String startDate;
+    private final String endDate;
+    private final double achievementRate;
+    private final int dailyLimit;
+    private final int averageDailySpending;
+    private final Map<String, Integer> spendingByDay;
+}

--- a/src/main/java/cheongsan/domain/deposit/mapper/DepositMapper.java
+++ b/src/main/java/cheongsan/domain/deposit/mapper/DepositMapper.java
@@ -35,4 +35,10 @@ public interface DepositMapper {
     );
 
     BigDecimal sumTodaySpendingByUserId(Long userId);
+
+    List<Transaction> findWithdrawTransactionsByPeriod(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
 }

--- a/src/main/java/cheongsan/domain/deposit/service/ReportService.java
+++ b/src/main/java/cheongsan/domain/deposit/service/ReportService.java
@@ -1,0 +1,8 @@
+package cheongsan.domain.deposit.service;
+
+import cheongsan.domain.deposit.dto.WeeklyReportDTO;
+
+public interface ReportService {
+
+    WeeklyReportDTO getLatestWeeklyReport(Long userId);
+}

--- a/src/main/java/cheongsan/domain/deposit/service/ReportServiceImpl.java
+++ b/src/main/java/cheongsan/domain/deposit/service/ReportServiceImpl.java
@@ -1,0 +1,79 @@
+package cheongsan.domain.deposit.service;
+
+import cheongsan.common.constant.ResponseMessage;
+import cheongsan.domain.deposit.dto.WeeklyReportDTO;
+import cheongsan.domain.deposit.entity.Transaction;
+import cheongsan.domain.deposit.mapper.DepositMapper;
+import cheongsan.domain.user.entity.User;
+import cheongsan.domain.user.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ReportServiceImpl implements ReportService {
+
+    private final UserMapper userMapper;
+    private final DepositMapper depositMapper;
+
+    @Override
+    public WeeklyReportDTO getLatestWeeklyReport(Long userId) {
+        User user = userMapper.findById(userId);
+        if (user == null) {
+            throw new IllegalArgumentException(ResponseMessage.USER_NOT_FOUND.getMessage());
+        }
+        int dailyLimit = (user.getDailyLimit() != null) ? user.getDailyLimit().intValue() : 0;
+
+        LocalDate today = LocalDate.now();
+        LocalDate lastMonday = today.minusWeeks(1).with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate lastSunday = today.minusWeeks(1).with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+
+        List<Transaction> lastWeekWithdraws = depositMapper.findWithdrawTransactionsByPeriod(userId, lastMonday, lastSunday);
+
+        Map<DayOfWeek, Integer> spendingByDayMap = calculateSpendingByDay(lastWeekWithdraws);
+        long totalSpending = spendingByDayMap.values().stream().mapToLong(Integer::longValue).sum();
+        long daysWithinLimit = spendingByDayMap.values().stream().filter(spent -> spent <= dailyLimit).count();
+
+        double achievementRate = (daysWithinLimit / 7.0) * 100.0;
+        int averageDailySpending = (int) (totalSpending / 7);
+
+        return WeeklyReportDTO.builder()
+                .startDate(lastMonday.format(DateTimeFormatter.ISO_LOCAL_DATE))
+                .endDate(lastSunday.format(DateTimeFormatter.ISO_LOCAL_DATE))
+                .achievementRate(achievementRate)
+                .dailyLimit(dailyLimit)
+                .averageDailySpending(averageDailySpending)
+                .spendingByDay(formatSpendingByDay(spendingByDayMap))
+                .build();
+    }
+
+    private Map<DayOfWeek, Integer> calculateSpendingByDay(List<Transaction> withdraws) {
+        Map<DayOfWeek, Integer> spendingByDay = new EnumMap<>(DayOfWeek.class);
+        for (DayOfWeek day : DayOfWeek.values()) {
+            spendingByDay.put(day, 0); // 모든 요일을 0으로 초기화
+        }
+
+        for (Transaction withdraw : withdraws) {
+            DayOfWeek day = withdraw.getTransactionTime().getDayOfWeek();
+            spendingByDay.compute(day, (k, currentAmount) -> currentAmount + withdraw.getAmount().intValue());
+        }
+        return spendingByDay;
+    }
+
+    private Map<String, Integer> formatSpendingByDay(Map<DayOfWeek, Integer> spendingByDayMap) {
+        Map<String, Integer> formattedMap = new LinkedHashMap<>();
+        for (DayOfWeek day : DayOfWeek.values()) {
+            formattedMap.put(day.name().substring(0, 3), spendingByDayMap.get(day));
+        }
+        return formattedMap;
+    }
+}

--- a/src/main/resources/mapper/DepositMapper.xml
+++ b/src/main/resources/mapper/DepositMapper.xml
@@ -5,16 +5,14 @@
 <mapper namespace="cheongsan.domain.deposit.mapper.DepositMapper">
 
     <select id="getMonthlyTransactions" resultType="cheongsan.domain.deposit.dto.MonthlyTransactionDTO">
-        SELECT DATE(t.transaction_time)                                                 AS transactionDate,
-               COALESCE(SUM(CASE WHEN t.type = 'TRANSFER' THEN t.amount ELSE 0 END), 0) AS totalIncome,
-               COALESCE(SUM(CASE WHEN t.type = 'WITHDRAW' THEN t.amount ELSE 0 END), 0) AS totalExpense,
-               COUNT(*)                                                                 AS transactionCount
+        SELECT DATE (t.transaction_time) AS transactionDate, COALESCE (SUM (CASE WHEN t.type = 'TRANSFER' THEN t.amount ELSE 0 END), 0) AS totalIncome, COALESCE (SUM (CASE WHEN t.type = 'WITHDRAW' THEN t.amount ELSE 0 END), 0) AS totalExpense, COUNT (*) AS transactionCount
         FROM transactions t
-                 INNER JOIN deposit_accounts da ON t.deposit_account_id = da.id
+            INNER JOIN deposit_accounts da
+        ON t.deposit_account_id = da.id
         WHERE t.user_id = #{userId}
-          AND YEAR(t.transaction_time) = #{year}
-          AND MONTH(t.transaction_time) = #{month}
-        GROUP BY DATE(t.transaction_time)
+          AND YEAR (t.transaction_time) = #{year}
+          AND MONTH (t.transaction_time) = #{month}
+        GROUP BY DATE (t.transaction_time)
         ORDER BY transactionDate ASC
     </select>
 
@@ -30,7 +28,7 @@
         FROM transactions t
                  INNER JOIN deposit_accounts da ON t.deposit_account_id = da.id
         WHERE t.user_id = #{userId}
-          AND DATE(t.transaction_time) = #{date}
+          AND DATE (t.transaction_time) = #{date}
         ORDER BY t.transaction_time DESC
     </select>
 
@@ -47,9 +45,10 @@
                res_account_desc3
         FROM transactions
         WHERE user_id = #{userId}
-          AND type = 'TRANSFER'
-          AND YEAR(transaction_time) = #{year}
-          AND MONTH(transaction_time) = #{month}
+            AND type = 'TRANSFER'
+            AND YEAR (
+            transaction_time) = #{year}
+          AND MONTH (transaction_time) = #{month}
     </select>
 
     <select id="findWithdrawTransactionsByMonth" resultType="cheongsan.domain.deposit.entity.Transaction">
@@ -65,9 +64,10 @@
                res_account_desc3
         FROM transactions
         WHERE user_id = #{userId}
-          AND type = 'WITHDRAW'
-          AND YEAR(transaction_time) = #{year}
-          AND MONTH(transaction_time) = #{month}
+            AND type = 'WITHDRAW'
+            AND YEAR (
+            transaction_time) = #{year}
+          AND MONTH (transaction_time) = #{month}
     </select>
 
     <select id="sumTodaySpendingByUserId" resultType="java.math.BigDecimal">
@@ -75,7 +75,16 @@
         FROM transactions
         WHERE user_id = #{userId}
           AND type = 'WITHDRAW'
-          AND DATE(transaction_time) = CURDATE()
+          AND DATE (transaction_time) = CURDATE()
+    </select>
+
+    <select id="findWithdrawTransactionsByPeriod" resultType="cheongsan.domain.deposit.entity.Transaction">
+        SELECT *
+        FROM transactions
+        WHERE user_id = #{userId}
+          AND type = 'WITHDRAW'
+          AND DATE (transaction_time) BETWEEN #{startDate}
+          AND #{endDate}
     </select>
 
 </mapper>

--- a/src/test/java/cheongsan/domain/deposit/mapper/DepositMapperTest.java
+++ b/src/test/java/cheongsan/domain/deposit/mapper/DepositMapperTest.java
@@ -11,6 +11,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -97,5 +100,43 @@ class DepositMapperTest {
         // then
         assertEquals(0, BigDecimal.ZERO.compareTo(totalSpending), "거래 내역이 없으면 합계는 0이어야 합니다.");
         log.info("거래 내역이 없는 사용자(3L)의 총 지출액: " + totalSpending);
+    }
+
+    @Test
+    @DisplayName("특정 기간 동안의 지출 내역만 정확히 조회해야 한다")
+    void findWithdrawTransactionsByPeriod() {
+        // given
+        Long userId = 1L;
+        LocalDate today = LocalDate.now();
+        LocalDate lastMonday = today.minusWeeks(1).with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate lastSunday = today.minusWeeks(1).with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+
+        // when
+        List<Transaction> result = mapper.findWithdrawTransactionsByPeriod(userId, lastMonday, lastSunday);
+
+        // then
+        assertNotNull(result, "결과 리스트는 null이 아니어야 합니다.");
+        assertEquals(2, result.size(), "User 1의 지난주 지출 내역은 2건이어야 합니다.");
+        assertTrue(result.stream().allMatch(tx -> tx.getType().equals("WITHDRAW")), "조회된 모든 거래는 'WITHDRAW' 타입이어야 합니다.");
+        log.info("조회된 거래내역 건수: " + result.size());
+        log.info("조회된 거래내역: " + result);
+    }
+
+    @Test
+    @DisplayName("해당 기간에 지출 내역이 없는 경우, 빈 리스트를 반환해야 한다")
+    void findWithdrawTransactionsByPeriod_NoResult() {
+        // given
+        Long userId = 2L;
+        LocalDate today = LocalDate.now();
+        LocalDate lastMonday = today.minusWeeks(1).with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate lastSunday = today.minusWeeks(1).with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+
+        // when
+        List<Transaction> result = mapper.findWithdrawTransactionsByPeriod(userId, lastMonday, lastSunday);
+
+        // then
+        assertNotNull(result, "결과 리스트는 null이 아니어야 합니다.");
+        assertTrue(result.isEmpty(), "User 2의 지난주 지출 내역은 없으므로 결과는 빈 리스트여야 합니다.");
+        log.info("지출 내역 없는 사용자의 조회 결과: " + result);
     }
 }

--- a/src/test/java/cheongsan/domain/deposit/service/ReportServiceImplTest.java
+++ b/src/test/java/cheongsan/domain/deposit/service/ReportServiceImplTest.java
@@ -1,0 +1,59 @@
+package cheongsan.domain.deposit.service;
+
+import cheongsan.common.config.RootConfig;
+import cheongsan.domain.deposit.dto.WeeklyReportDTO;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {RootConfig.class})
+@Log4j2
+class ReportServiceImplTest {
+
+    @Autowired
+    private ReportServiceImpl reportService;
+
+    @Test
+    @DisplayName("지난주 지출 리포트의 모든 지표를 정확히 계산해야 한다")
+    void getLatestWeeklyReport() {
+        // given
+        Long userId = 1L;
+
+        // when
+        WeeklyReportDTO result = reportService.getLatestWeeklyReport(userId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(12857, result.getAverageDailySpending(), "일일 평균 지출액이 일치해야 합니다.");
+        assertEquals(50000, result.getDailyLimit(), "일일 소비 한도가 일치해야 합니다.");
+        assertEquals(85.71, result.getAchievementRate(), 0.01, "목표 달성률이 일치해야 합니다."); // 소수점 둘째 자리까지 비교
+        assertEquals(10000, result.getSpendingByDay().get("MON"), "월요일 지출액이 일치해야 합니다.");
+        assertEquals(0, result.getSpendingByDay().get("THU"), "목요일 지출액은 0이어야 합니다.");
+        log.info("정상 사용자 리포트 결과: " + result);
+    }
+
+    @Test
+    @DisplayName("지난주 지출이 없는 경우, 모든 지표가 0으로 계산되어야 한다")
+    void getLatestWeeklyReport_NoSpending() {
+        // given
+        Long userId = 2L;
+
+        // when
+        WeeklyReportDTO result = reportService.getLatestWeeklyReport(userId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(0, result.getAverageDailySpending(), "평균 지출액은 0이어야 합니다.");
+        assertEquals(35000, result.getDailyLimit()); // 일일 한도는 정상 표시
+        assertEquals(100.0, result.getAchievementRate(), 0.01, "지출이 없으면 달성률은 100%여야 합니다.");
+        log.info("지출 없는 사용자 리포트 결과: " + result);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

#48 

## 📝 요약(Summary)

- GET /dashboard/reports/weekly 엔드포인트 생성
- 오늘 날짜를 기준으로 지난주(월요일~일요일)의 시작일과 종료일을 계산하는 로직 구현
- transactions 테이블에서 해당 사용자의 지난주 모든 지출 내역을 조회하는 쿼리 작성
- 조회된 지출 내역을 바탕으로 '요일별 지출액', '일일 평균 지출액', '목표 달성률'을 계산하는 로직 구현
- 계산된 모든 리포트 데이터를 DTO에 담아 반환하도록 API 완성

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
`int averageDailySpending = (int) (totalSpending / 7);`
일일 평균 지출액은 내림으로 처리하였습니다.
- 추천 일일 소비 한도 계산 시, 보수적인 기준으로 추천해주기 위해 내림 사용.
- 일일 평균 지출액도 서비스 전체의 일관성을 유지하기 위해 내림으로 처리.
- 사용자가 실제 쓴 돈보다 적게 썼다고 생각할 수 있지만 그 차이는 미비하다고 생각했습니다.
- 34,500.7원 -> 34,500원

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
