### PR TITLE
[Refactor] DebtMapper의 getLoanDetail수정 #53

### DIFF
--- a/src/main/java/cheongsan/domain/debt/dto/DebtDetailResponseDTO.java
+++ b/src/main/java/cheongsan/domain/debt/dto/DebtDetailResponseDTO.java
@@ -1,11 +1,15 @@
 package cheongsan.domain.debt.dto;
 
+import cheongsan.domain.debt.entity.DebtAccount;
+import cheongsan.domain.debt.entity.FinancialInstitution;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
 import lombok.Data;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 @Data
+@Builder
 public class DebtDetailResponseDTO {
     private String debtName;
     private String organizationName;
@@ -13,9 +17,22 @@ public class DebtDetailResponseDTO {
     private Double interestRate;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-    private Date loanStartDate;
+    private LocalDate loanStartDate;
 
     private Double currentBalance;
-    private Integer gracePeriodMonths;
+    private Long gracePeriodMonths;
     private String repaymentMethod;
+
+    public static DebtDetailResponseDTO fromEntity(DebtAccount da, FinancialInstitution fi) {
+        return DebtDetailResponseDTO.builder()
+                .debtName(da.getDebtName())
+                .organizationName(fi.getOrganizationName())
+                .originalAmount(da.getOriginalAmount().longValue())
+                .interestRate(da.getInterestRate().doubleValue())
+                .loanStartDate(da.getLoanStartDate())
+                .currentBalance(da.getCurrentBalance().doubleValue())
+                .gracePeriodMonths(da.getGracePeriodMonths())
+                .repaymentMethod(da.getRepaymentMethod())
+                .build();
+    }
 }

--- a/src/main/java/cheongsan/domain/debt/mapper/DebtMapper.java
+++ b/src/main/java/cheongsan/domain/debt/mapper/DebtMapper.java
@@ -1,9 +1,13 @@
 package cheongsan.domain.debt.mapper;
 
-import cheongsan.domain.debt.dto.*;
+import cheongsan.domain.debt.dto.DailyRepaymentDTO;
+import cheongsan.domain.debt.dto.DebtDTO;
+import cheongsan.domain.debt.dto.DebtInfoResponseDTO;
+import cheongsan.domain.debt.dto.RepaymentCalendarDTO;
 import cheongsan.domain.debt.entity.DebtAccount;
 import cheongsan.domain.debt.entity.DebtRepaymentRatio;
 import cheongsan.domain.debt.entity.DelinquentLoan;
+import cheongsan.domain.debt.entity.FinancialInstitution;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -14,7 +18,11 @@ import java.util.List;
 public interface DebtMapper {
     List<DebtInfoResponseDTO> getUserDebtList(Long userId);
 
-    DebtDetailResponseDTO getLoanDetail(Long loanId);
+    // 대출 상세 조회 (1)
+    DebtAccount getDebtAccountById(Long loanId);
+
+    // 대출 상세 조회 (2)
+    FinancialInstitution getFinancialInstitutionByCode(Long organizationCode);
 
     List<DebtDTO> findByUserId(Long userId);
 

--- a/src/main/java/cheongsan/domain/debt/service/DebtServiceImpl.java
+++ b/src/main/java/cheongsan/domain/debt/service/DebtServiceImpl.java
@@ -5,6 +5,7 @@ import cheongsan.domain.debt.dto.*;
 import cheongsan.domain.debt.entity.DebtAccount;
 import cheongsan.domain.debt.entity.DebtRepaymentRatio;
 import cheongsan.domain.debt.entity.DelinquentLoan;
+import cheongsan.domain.debt.entity.FinancialInstitution;
 import cheongsan.domain.debt.mapper.DebtMapper;
 import cheongsan.domain.debt.mapper.FinancialInstitutionMapper;
 import lombok.RequiredArgsConstructor;
@@ -71,7 +72,12 @@ public class DebtServiceImpl implements DebtService {
 
     @Override
     public DebtDetailResponseDTO getLoanDetail(Long loanId) {
-        return debtMapper.getLoanDetail(loanId);
+        DebtAccount debtAccount = debtMapper.getDebtAccountById(loanId);
+
+        FinancialInstitution fi = debtMapper.getFinancialInstitutionByCode(debtAccount.getOrganizationCode());
+
+        // DTO 변환 및 반환
+        return DebtDetailResponseDTO.fromEntity(debtAccount, fi);
     }
 
     @Override

--- a/src/main/resources/mapper/DebtMapper.xml
+++ b/src/main/resources/mapper/DebtMapper.xml
@@ -19,19 +19,26 @@
         WHERE da.user_id = #{userId}
     </select>
 
-    <!-- 대출별 상세 조회-->
-    <select id="getLoanDetail" parameterType="long" resultType="cheongsan.domain.debt.dto.DebtDetailResponseDTO">
-        SELECT da.debt_name           AS debtName,
-               fi.organization_name   AS organizationName,
-               da.original_amount     AS originalAmount,
-               da.interest_rate       AS interestRate,
-               da.loan_start_date     AS loanStartDate,
-               da.current_balance     AS currentBalance,
-               da.grace_period_months AS gracePeriodMonths,
-               da.repayment_method    AS repaymentMethod
-        FROM debt_accounts da
-                 JOIN financial_institutions fi ON da.organization_code = fi.organization_code
-        WHERE da.id = #{loanId}
+    <select id="getDebtAccountById" parameterType="long" resultType="cheongsan.domain.debt.entity.DebtAccount">
+        SELECT id AS debtAccountId,
+               debt_name,
+               original_amount,
+               current_balance,
+               interest_rate,
+               loan_start_date,
+               grace_period_months,
+               repayment_method,
+               organization_code
+        FROM debt_accounts
+        WHERE id = #{loanId}
+    </select>
+
+    <select id="getFinancialInstitutionByCode" parameterType="string"
+            resultType="cheongsan.domain.debt.entity.FinancialInstitution">
+        SELECT organization_code AS organizationCode,
+               organization_name AS organizationName
+        FROM financial_institutions
+        WHERE organization_code = #{organizationCode}
     </select>
 
     <select id="findByUserId" resultType="cheongsan.domain.debt.dto.DebtDTO">


### PR DESCRIPTION
## #️⃣ Issue Number

#53 

## 📝 요약(Summary)
기존 코드 )
- 대출별 상세 조회 시,  DebtMapper의 getLoanDetail에서 두 테이블을 조인하여 바로 dto에 저장한다.

리팩토링 후 코드 )
- DebtMapper.xml : 상세 조회에 필요한 두 테이블을 각각 엔티티에 저장. (getDebtAccountById, getFinancialInstitutionByCode)
- DebtDetailResponseDTO.java : dto 클래스 내부에서, 두 엔티티로부터 응답 dto를 생성하는 fromEntity 정의

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
