### PR TITLE
[Feature] 일일 소비 한도 초과 시 이메일 알림 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,8 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitVersion}")
 
     testImplementation 'org.assertj:assertj-core:3.25.3'
+
+    testImplementation 'org.apache.tomcat.embed:tomcat-embed-websocket:9.0.105'
 }
 
 

--- a/src/main/java/cheongsan/domain/deposit/service/LimitCheckService.java
+++ b/src/main/java/cheongsan/domain/deposit/service/LimitCheckService.java
@@ -1,0 +1,6 @@
+package cheongsan.domain.deposit.service;
+
+public interface LimitCheckService {
+
+    void checkDailyLimitExceeded(Long userId);
+}

--- a/src/main/java/cheongsan/domain/deposit/service/LimitCheckServiceImpl.java
+++ b/src/main/java/cheongsan/domain/deposit/service/LimitCheckServiceImpl.java
@@ -1,0 +1,64 @@
+package cheongsan.domain.deposit.service;
+
+import cheongsan.domain.deposit.mapper.DepositMapper;
+import cheongsan.domain.notification.entity.Notification;
+import cheongsan.domain.notification.mapper.NotificationMapper;
+import cheongsan.domain.notification.service.NotificationService;
+import cheongsan.domain.user.entity.User;
+import cheongsan.domain.user.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class LimitCheckServiceImpl implements LimitCheckService {
+
+    private final UserMapper userMapper;
+    private final DepositMapper depositMapper;
+    private final NotificationMapper notificationMapper;
+    private final NotificationService notificationService;
+
+    private static final String NOTIFICATION_TYPE_LIMIT_EXCEEDED = "DAILY_LIMIT_EXCEEDED";
+
+    @Override
+    @Transactional
+    public void checkDailyLimitExceeded(Long userId) {
+        int sentCount = notificationMapper.countTodayNotificationsByType(userId, NOTIFICATION_TYPE_LIMIT_EXCEEDED);
+        if (sentCount > 0) {
+            log.info("사용자(ID: {})는 오늘 이미 한도 초과 알림을 받았습니다. 중복 발송을 방지합니다.", userId);
+            return; // 이미 보냈으면 로직 종료
+        }
+
+        User user = userMapper.findById(userId);
+        if (user == null) {
+            log.warn("사용자(ID: {}) 정보가 없어 검사를 건너뜁니다.", userId);
+            return;
+        }
+        int dailyLimit = user.getDailyLimit().intValue();
+        BigDecimal todaySpent = depositMapper.sumTodaySpendingByUserId(userId);
+
+        if (todaySpent.intValue() > dailyLimit) {
+            log.info("사용자(ID: {})의 한도 초과를 감지하여 알림 프로세스를 시작합니다.", userId);
+
+            // 이메일 발송 (비동기 처리)
+            notificationService.sendDailyLimitExceededEmail(user, dailyLimit, todaySpent.intValue());
+
+            Notification newNotification = Notification.builder()
+                    .userId(userId)
+                    .contents(String.format("일일 한도(%d원)를 초과했습니다. (오늘 지출:%d원)", dailyLimit, todaySpent.intValue()))
+                    .type(NOTIFICATION_TYPE_LIMIT_EXCEEDED)
+                    .isRead(false)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+
+            // 발송 사실을 DB에 저장
+            notificationMapper.save(newNotification);
+        }
+    }
+}

--- a/src/main/java/cheongsan/domain/notification/mapper/NotificationMapper.java
+++ b/src/main/java/cheongsan/domain/notification/mapper/NotificationMapper.java
@@ -12,5 +12,9 @@ public interface NotificationMapper {
 
     int countUnreadNotificationByUserId(@Param("userId") Long userId);
 
+    int countTodayNotificationsByType(@Param("userId") Long userId, @Param("type") String type);
+
+    void save(Notification notification);
+
     void markNotificationAsRead(@Param("userId") Long id);
 }

--- a/src/main/java/cheongsan/domain/notification/service/NotificationService.java
+++ b/src/main/java/cheongsan/domain/notification/service/NotificationService.java
@@ -1,6 +1,7 @@
 package cheongsan.domain.notification.service;
 
 import cheongsan.domain.notification.dto.NotificationDTO;
+import cheongsan.domain.user.entity.User;
 
 import java.util.List;
 
@@ -13,4 +14,6 @@ public interface NotificationService {
 
     // 알림 읽음 처리
     void markAsRead(Long userId);
+
+    void sendDailyLimitExceededEmail(User user, int dailyLimit, int totalSpent);
 }

--- a/src/main/resources/mapper/NotificationMapper.xml
+++ b/src/main/resources/mapper/NotificationMapper.xml
@@ -19,6 +19,19 @@
           AND is_read = 0
     </select>
 
+    <select id="countTodayNotificationsByType" resultType="java.lang.Integer">
+        SELECT COUNT(*)
+        FROM notifications
+        WHERE user_id = #{userId}
+          AND type = #{type}
+          AND DATE(created_at) = CURDATE()
+    </select>
+
+    <insert id="save" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO notifications (user_id, contents, type, is_read, created_at)
+        VALUES (#{userId}, #{contents}, #{type}, #{isRead}, #{createdAt})
+    </insert>
+
     <update id="markNotificationAsRead">
         UPDATE notifications
         SET is_read = 1

--- a/src/test/java/cheongsan/domain/deposit/service/LimitCheckServiceImplTest.java
+++ b/src/test/java/cheongsan/domain/deposit/service/LimitCheckServiceImplTest.java
@@ -1,0 +1,44 @@
+package cheongsan.domain.deposit.service;
+
+import cheongsan.common.config.RootConfig;
+import cheongsan.domain.notification.mapper.NotificationMapper;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {RootConfig.class})
+@Log4j2
+class LimitCheckServiceImplTest {
+
+    @Autowired
+    private LimitCheckServiceImpl limitCheckService;
+
+    @Autowired
+    private NotificationMapper notificationMapper;
+
+    @Test
+    @DisplayName("한도를 초과한 사용자에게 메일을 발송하고 DB에 기록해야 한다")
+    void checkDailyLimitExceeded_ShouldNotifyAndSave() {
+        // given
+        Long userId = 1L;
+        log.info("실제 이메일 발송 테스트를 시작합니다...");
+
+        // when
+        assertDoesNotThrow(() -> {
+            limitCheckService.checkDailyLimitExceeded(userId);
+        });
+
+        // then
+        int notifyCount = notificationMapper.countTodayNotificationsByType(userId, "DAILY_LIMIT_EXCEEDED");
+        assertEquals(1, notifyCount, "DB에 한도 초과 알림이 1건 기록되어야 합니다.");
+
+        log.info("이메일 발송 요청이 성공적으로 완료되었습니다. 메일함을 확인해주세요.");
+    }
+}

--- a/src/test/java/cheongsan/domain/notification/mapper/NotificationMapperTest.java
+++ b/src/test/java/cheongsan/domain/notification/mapper/NotificationMapperTest.java
@@ -1,0 +1,76 @@
+package cheongsan.domain.notification.mapper;
+
+import cheongsan.common.config.RootConfig;
+import cheongsan.domain.notification.entity.Notification;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {RootConfig.class})
+@Log4j2
+class NotificationMapperTest {
+
+    @Autowired
+    private NotificationMapper notificationMapper;
+
+    @Test
+    @Transactional
+    @DisplayName("새로운 알림을 성공적으로 저장하고, 생성된 ID를 반환해야 한다")
+    void save() {
+        // given
+        Notification newNotification = Notification.builder()
+                .userId(2L)
+                .contents("테스트 메시지")
+                .type("DAILY_LIMIT_EXCEEDED")
+                .isRead(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        // when
+        notificationMapper.save(newNotification);
+
+        // then
+        assertNotNull(newNotification.getId(), "INSERT 후에는 ID가 생성되어야 합니다.");
+        log.info("생성된 알림 ID: " + newNotification.getId());
+    }
+
+    @Test
+    @DisplayName("오늘 특정 유형의 알림이 있는 경우, 정확한 개수를 반환해야 한다")
+    void countTodayNotificationsByType_WhenNotificationsExist() {
+        // given
+        Long userId = 1L;
+        String type = "DAILY_LIMIT_EXCEEDED";
+
+        // when
+        int count = notificationMapper.countTodayNotificationsByType(userId, type);
+
+        // then
+        assertEquals(1, count, "오늘 날짜로 생성된 한도 초과 알림은 1개여야 합니다.");
+        log.info("조회된 알림 개수: " + count);
+    }
+
+    @Test
+    @DisplayName("오늘 특정 유형의 알림이 없는 경우, 0을 반환해야 한다")
+    void countTodayNotificationsByType_WhenNotificationsDoNotExist() {
+        // given
+        Long userId = 2L;
+        String type = "DAILY_LIMIT_EXCEEDED";
+
+        // when
+        int count = notificationMapper.countTodayNotificationsByType(userId, type);
+
+        // then
+        assertEquals(0, count, "알림이 없으므로 0을 반환해야 합니다.");
+        log.info("조회된 알림 개수: " + count);
+    }
+}

--- a/src/test/java/cheongsan/domain/notification/service/NotificationServiceImplTest.java
+++ b/src/test/java/cheongsan/domain/notification/service/NotificationServiceImplTest.java
@@ -1,0 +1,46 @@
+package cheongsan.domain.notification.service;
+
+import cheongsan.common.config.RootConfig;
+import cheongsan.domain.user.entity.User;
+import cheongsan.domain.user.mapper.UserMapper;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { RootConfig.class })
+@Log4j2
+class NotificationServiceImplTest {
+
+    @Autowired
+    private NotificationServiceImpl notificationService;
+
+    @Autowired
+    private UserMapper userMapper;
+
+    @Test
+    @DisplayName("실제 이메일 서버를 통해 한도 초과 알림 메일을 발송해야 한다")
+    void sendDailyLimitExceededEmail() {
+        // given
+        Long userId = 1L;
+        User user = userMapper.findById(userId);
+
+        int dailyLimit = 50000;
+        int totalSpent = 52000;
+
+        log.info(user.getEmail() + " 주소로 실제 이메일 발송을 시도합니다...");
+
+        // when & then
+        assertDoesNotThrow(() -> {
+            notificationService.sendDailyLimitExceededEmail(user, dailyLimit, totalSpent);
+        });
+
+        log.info("이메일 발송 요청이 성공적으로 완료되었습니다. 메일함을 확인해주세요.");
+    }
+}

--- a/src/test/java/cheongsan/domain/user/controller/AuthControllerTest.java
+++ b/src/test/java/cheongsan/domain/user/controller/AuthControllerTest.java
@@ -40,6 +40,11 @@ class AuthControllerTest {
         public FindUserPasswordResponseDTO findUserPassword(FindUserPasswordRequestDTO findUserPasswordRequestDTO) {
             return null;
         }
+
+        @Override
+        public void changePassword(ChangePasswordRequestDTO changePasswordRequestDTO) {
+
+        }
     }
 
     @BeforeEach


### PR DESCRIPTION
## #️⃣ Issue Number

#58 

## 📝 요약(Summary)

- 거래내역 동기화 후 호출될 한도 초과 검사 서비스 로직 구현
  - 해당 사용자의 '오늘 총지출액'을 다시 계산
  - 계산된 총지출액이 '일일 한도'를 초과했는지 확인
- 한도를 초과했을 경우, 이메일 발송 로직 구현
- 하루에 동일한 한도 초과 알림이 여러 번 발송되지 않도록, 발송 여부를 DB에 저장하고 중복을 방지하는 로직 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
1. `testImplementation 'org.apache.tomcat.embed:tomcat-embed-websocket:9.0.105'`
  테스트 할 때 websocket 관련 오류가 발생해서 build.gradle에 테스트를 실행할 때만 사용할 내장 Tomcat 서버 의존성 추가하였습니다.

2. CODEF API 스케줄러 구현 시, deposit 도메인에 있는 LimitCheckServiceImpl.java 파일 이용하시면 됩니다!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
