### PR TITLE
[Refactor] 한도 저장 API가 저장된 최신 결과를 직접 반환하도록 수정

### DIFF
--- a/src/main/java/cheongsan/common/constant/ResponseMessage.java
+++ b/src/main/java/cheongsan/common/constant/ResponseMessage.java
@@ -7,7 +7,6 @@ public enum ResponseMessage {
 
     // --- 성공 ---
     LOGOUT_SUCCESS("로그아웃 되었습니다."),
-    BUDGET_LIMIT_SAVED("일일 소비 한도가 성공적으로 저장되었습니다."),
 
     // --- 에러 ---
     INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다."),

--- a/src/main/java/cheongsan/domain/deposit/controller/BudgetController.java
+++ b/src/main/java/cheongsan/domain/deposit/controller/BudgetController.java
@@ -9,10 +9,8 @@ import cheongsan.domain.user.entity.CustomUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.security.Principal;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,27 +20,21 @@ public class BudgetController {
     private final BudgetService budgetService;
 
     @GetMapping("/recommendation")
-    public ResponseEntity<BudgetLimitDTO> getBudgetLimits(Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        CustomUser customUser = (CustomUser) authentication.getPrincipal();
+    public ResponseEntity<BudgetLimitDTO> getBudgetLimits(@AuthenticationPrincipal CustomUser customUser) {
         Long userId = customUser.getUser().getId();
         BudgetLimitDTO result = budgetService.getBudgetLimits(userId);
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
     @PatchMapping
-    public ResponseEntity<DailySpendingDTO> saveFinalDailyLimit(@RequestBody DailyLimitRequestDTO request, Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        CustomUser customUser = (CustomUser) authentication.getPrincipal();
+    public ResponseEntity<DailySpendingDTO> saveFinalDailyLimit(@RequestBody DailyLimitRequestDTO request, @AuthenticationPrincipal CustomUser customUser) {
         Long userId = customUser.getUser().getId();
         DailySpendingDTO updatedSpendingData = budgetService.saveFinalDailyLimit(userId, request.getDailyLimit());
         return new ResponseEntity<>(updatedSpendingData, HttpStatus.OK);
     }
 
     @GetMapping("/status")
-    public ResponseEntity<BudgetSettingStatusDTO> getBudgetSettingStatus(Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        CustomUser customUser = (CustomUser) authentication.getPrincipal();
+    public ResponseEntity<BudgetSettingStatusDTO> getBudgetSettingStatus(@AuthenticationPrincipal CustomUser customUser) {
         Long userId = customUser.getUser().getId();
         BudgetSettingStatusDTO result = budgetService.getBudgetSettingStatus(userId);
         return new ResponseEntity<>(result, HttpStatus.OK);

--- a/src/main/java/cheongsan/domain/deposit/controller/BudgetController.java
+++ b/src/main/java/cheongsan/domain/deposit/controller/BudgetController.java
@@ -1,10 +1,9 @@
 package cheongsan.domain.deposit.controller;
 
-import cheongsan.common.constant.ResponseMessage;
-import cheongsan.common.exception.ResponseDTO;
 import cheongsan.domain.deposit.dto.BudgetLimitDTO;
 import cheongsan.domain.deposit.dto.BudgetSettingStatusDTO;
 import cheongsan.domain.deposit.dto.DailyLimitRequestDTO;
+import cheongsan.domain.deposit.dto.DailySpendingDTO;
 import cheongsan.domain.deposit.service.BudgetService;
 import cheongsan.domain.user.entity.CustomUser;
 import lombok.RequiredArgsConstructor;
@@ -32,13 +31,12 @@ public class BudgetController {
     }
 
     @PatchMapping
-    public ResponseEntity<ResponseDTO> saveFinalDailyLimit(@RequestBody DailyLimitRequestDTO request, Principal principal) {
+    public ResponseEntity<DailySpendingDTO> saveFinalDailyLimit(@RequestBody DailyLimitRequestDTO request, Principal principal) {
         Authentication authentication = (Authentication) principal;
         CustomUser customUser = (CustomUser) authentication.getPrincipal();
         Long userId = customUser.getUser().getId();
-        budgetService.saveFinalDailyLimit(userId, request.getDailyLimit());
-        ResponseDTO response = new ResponseDTO(ResponseMessage.BUDGET_LIMIT_SAVED.getMessage());
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        DailySpendingDTO updatedSpendingData = budgetService.saveFinalDailyLimit(userId, request.getDailyLimit());
+        return new ResponseEntity<>(updatedSpendingData, HttpStatus.OK);
     }
 
     @GetMapping("/status")

--- a/src/main/java/cheongsan/domain/deposit/controller/DepositController.java
+++ b/src/main/java/cheongsan/domain/deposit/controller/DepositController.java
@@ -11,11 +11,9 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.security.Principal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -75,9 +73,7 @@ public class DepositController {
     }
 
     @GetMapping("/dashboard/daily-spending")
-    public ResponseEntity<DailySpendingDTO> getDailySpendingStatus(Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        CustomUser customUser = (CustomUser) authentication.getPrincipal();
+    public ResponseEntity<DailySpendingDTO> getDailySpendingStatus(@AuthenticationPrincipal CustomUser customUser) {
         Long userId = customUser.getUser().getId();
         DailySpendingDTO result = dailySpendingService.getDailySpendingStatus(userId);
         return new ResponseEntity<>(result, HttpStatus.OK);

--- a/src/main/java/cheongsan/domain/deposit/controller/ReportController.java
+++ b/src/main/java/cheongsan/domain/deposit/controller/ReportController.java
@@ -1,7 +1,6 @@
 package cheongsan.domain.deposit.controller;
 
 import cheongsan.common.constant.ResponseMessage;
-import cheongsan.common.exception.ResponseDTO;
 import cheongsan.domain.deposit.dto.WeeklyReportDTO;
 import cheongsan.domain.deposit.dto.WeeklyReportHistoryDTO;
 import cheongsan.domain.deposit.service.ReportService;
@@ -10,10 +9,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.security.Principal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -24,9 +22,7 @@ public class ReportController {
     private final ReportService reportService;
 
     @GetMapping("/latest")
-    public ResponseEntity<?> getLatestWeeklyReport(Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        CustomUser customUser = (CustomUser) authentication.getPrincipal();
+    public ResponseEntity<?> getLatestWeeklyReport(@AuthenticationPrincipal CustomUser customUser) {
         Long userId = customUser.getUser().getId();
         WeeklyReportDTO result = reportService.getDashboardWeeklyReport(userId);
         if (result == null) {
@@ -36,18 +32,17 @@ public class ReportController {
     }
 
     @GetMapping
-    public ResponseEntity<WeeklyReportDTO> getWeeklyReportByDate(@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date, Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        CustomUser customUser = (CustomUser) authentication.getPrincipal();
+    public ResponseEntity<WeeklyReportDTO> getWeeklyReportByDate(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @AuthenticationPrincipal CustomUser customUser
+    ) {
         Long userId = customUser.getUser().getId();
         WeeklyReportDTO report = reportService.getReportByDate(userId, date);
         return new ResponseEntity<>(report, HttpStatus.OK);
     }
 
     @GetMapping("/history-list")
-    public ResponseEntity<List<WeeklyReportHistoryDTO>> getWeeklyReportHistoryList(Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        CustomUser customUser = (CustomUser) authentication.getPrincipal();
+    public ResponseEntity<List<WeeklyReportHistoryDTO>> getWeeklyReportHistoryList(@AuthenticationPrincipal CustomUser customUser) {
         Long userId = customUser.getUser().getId();
         List<WeeklyReportHistoryDTO> historyList = reportService.getReportHistoryList(userId);
         return new ResponseEntity<>(historyList, HttpStatus.OK);

--- a/src/main/java/cheongsan/domain/deposit/dto/DailySpendingDTO.java
+++ b/src/main/java/cheongsan/domain/deposit/dto/DailySpendingDTO.java
@@ -15,8 +15,8 @@ public class DailySpendingDTO {
     private final boolean systemRecommended;
     private final int remaining;
 
-    public static DailySpendingDTO getDailySpending(int dailyLimit, int spent, boolean isSystemRecommended) {
+    public static DailySpendingDTO getDailySpending(int dailyLimit, int spent, boolean systemRecommended) {
         int remaining = dailyLimit - spent;
-        return new DailySpendingDTO(dailyLimit, spent, isSystemRecommended, remaining);
+        return new DailySpendingDTO(dailyLimit, spent, systemRecommended, remaining);
     }
 }

--- a/src/main/java/cheongsan/domain/deposit/service/BudgetService.java
+++ b/src/main/java/cheongsan/domain/deposit/service/BudgetService.java
@@ -2,12 +2,13 @@ package cheongsan.domain.deposit.service;
 
 import cheongsan.domain.deposit.dto.BudgetLimitDTO;
 import cheongsan.domain.deposit.dto.BudgetSettingStatusDTO;
+import cheongsan.domain.deposit.dto.DailySpendingDTO;
 
 public interface BudgetService {
 
     BudgetLimitDTO getBudgetLimits(Long userId);
 
-    void saveFinalDailyLimit(Long userId, int finalDailyLimit);
+    DailySpendingDTO saveFinalDailyLimit(Long userId, int finalDailyLimit);
 
     BudgetSettingStatusDTO getBudgetSettingStatus(Long userId);
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#152 

## 📝 요약(Summary)

- 한도 저장 후 메인 대시보드에 바로 적용이 되지 않아서 PATCH 저장 API가 DB에 저장된 최신 '오늘의 지출 현황' 데이터를 직접 응답으로 반환하도록 수정
- BudgetController, DepositController, ReportController에 @AuthenticationPrincipal 적용

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
